### PR TITLE
Fix display_data in WriteRecordsToFile

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -236,7 +236,7 @@ class WriteRecordsToFile(beam.DoFn):
         'max_files_per_bundle': self.max_files_per_bundle,
         'max_file_size': str(self.max_file_size),
         'file_format': self.file_format,
-        'coder': self.coder,
+        'coder': self.coder.__class__,
     }
 
   def start_bundle(self):


### PR DESCRIPTION
# 무엇이 변경되었나요?

- WriteRecordsToFile에서 display_data를 coder의 `__class__`로 변경하였습니다.

# 참고사항
- display_data는 validation 과정에서 Primitive 타입들만 가능합니다. (즉, 인스턴스화된 객체를 Display Type로 설정할 수 없고, 이에 대한 클래스는 설정할 수 있음) https://github.com/apache/beam/blob/43d488c55cd25290c6f560f6649597fcc00dcc42/sdks/python/apache_beam/transforms/display.py#L420